### PR TITLE
ignoring empty lines and some other special char when prefixing

### DIFF
--- a/lib/colors.js
+++ b/lib/colors.js
@@ -26,10 +26,14 @@ var prefixWithColor = function(prefix, color_name) {
   return color + prefix + ": " + reset;
 };
 
+var charToIgnore = ["\n", "\b", "\t", "\r", "^C", " ", "", "^[[D", "^[[C", "^[[A", "^[[B"]
+
 var addPrefixToLines = function(data, prefix, color_name) {
   var lines = data.split("\n");
   for (line_id = 0; line_id < lines.length; line_id++ ) {
-    lines[line_id] = prefixWithColor(prefix, color_name) + lines[line_id];
+    if(charToIgnore.indexOf(lines[line_id]) < 0) {
+      lines[line_id] = prefixWithColor(prefix, color_name) + lines[line_id];
+    }
   }
   return lines.join("\n");
 };


### PR DESCRIPTION
Avoid the user typing \n to be prefixed during a tcp session
